### PR TITLE
refactor(webapp): remove default imports

### DIFF
--- a/webapp/.eslintrc
+++ b/webapp/.eslintrc
@@ -54,7 +54,8 @@
       {
         "argsIgnorePattern": "^_"
       }
-    ]
+    ],
+    "import/no-default-export": "error"
   },
   "overrides": [
     {
@@ -62,7 +63,18 @@
         "**/*.stories.*"
       ],
       "rules": {
-        "import/no-anonymous-default-export": "off"
+        // Next requires anonymous default export for Stories
+        "import/no-anonymous-default-export": "off",
+        "import/no-default-export": "off"
+      }
+    },
+    {
+      "files": [
+        "pages/**/*.tsx",
+        "cypress/**/*.ts"
+      ],
+      "rules": {
+        "import/no-default-export": "off" // Next requires default export for pages
       }
     }
   ]

--- a/webapp/.storybook/preview.tsx
+++ b/webapp/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import CssBaseline from '@mui/material/CssBaseline';
 
-import QueryClientProvider from '../src/providers/QueryClientProvider';
-import ThemeProvider from '../src/providers/ThemeProvider';
+import { QueryClientProvider } from '../src/providers/QueryClientProvider';
+import { ThemeProvider } from '../src/providers/ThemeProvider';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },

--- a/webapp/pages/404.tsx
+++ b/webapp/pages/404.tsx
@@ -1,3 +1,3 @@
-import FourOhFour from 'pages/404';
+import { FourOhFour } from 'pages/404';
 
 export default FourOhFour;

--- a/webapp/pages/_app.tsx
+++ b/webapp/pages/_app.tsx
@@ -1,9 +1,9 @@
 import { CssBaseline } from '@mui/material';
 import type { AppProps } from 'next/app';
-import AppProvider from 'providers/AppProvider';
+import { AppProvider } from 'providers/AppProvider';
 
 if (process.env.NEXT_PUBLIC_API_MOCKING === 'enabled') {
-  const enableMSW = require('../src/mocks').default; // eslint-disable-line @typescript-eslint/no-var-requires
+  const enableMSW = require('../src/mocks').enableMSW; // eslint-disable-line @typescript-eslint/no-var-requires
   enableMSW();
 }
 

--- a/webapp/pages/index.tsx
+++ b/webapp/pages/index.tsx
@@ -1,3 +1,3 @@
-import Home from 'pages/home';
+import { Home } from 'pages/home';
 
 export default Home;

--- a/webapp/pages/login.tsx
+++ b/webapp/pages/login.tsx
@@ -1,3 +1,3 @@
-import Login from 'pages/login';
+import { Login } from 'pages/login';
 
 export default Login;

--- a/webapp/pages/signup.tsx
+++ b/webapp/pages/signup.tsx
@@ -1,3 +1,3 @@
-import SignUp from 'pages/signup';
+import { SignUp } from 'pages/signup';
 
 export default SignUp;

--- a/webapp/src/backend/request.ts
+++ b/webapp/src/backend/request.ts
@@ -1,6 +1,6 @@
 import { GraphQLClient } from 'graphql-request';
 
-const request = (query: string, variables: unknown = {}) => {
+export const request = (query: string, variables: unknown = {}) => {
   const url = `${process.env.NEXT_PUBLIC_API_URL}/query`;
   const graphQLClient = new GraphQLClient(url);
 
@@ -11,5 +11,3 @@ const request = (query: string, variables: unknown = {}) => {
 
   return graphQLClient.request(query, variables);
 };
-
-export default request;

--- a/webapp/src/components/Link.tsx
+++ b/webapp/src/components/Link.tsx
@@ -2,7 +2,7 @@ import { Link as MuiLink } from '@mui/material';
 import RouterLink from 'next/link';
 import { ReactNode } from 'react';
 
-const Link = ({
+export const Link = ({
   href,
   children,
   underline = 'hover',
@@ -15,5 +15,3 @@ const Link = ({
     <MuiLink underline={underline}>{children}</MuiLink>
   </RouterLink>
 );
-
-export default Link;

--- a/webapp/src/components/Loading.stories.tsx
+++ b/webapp/src/components/Loading.stories.tsx
@@ -1,9 +1,9 @@
 import { Meta, Story } from '@storybook/react';
 
-import Loader, { Props } from './Loader';
+import { Loading, Props } from './Loading';
 
 const Template: Story<Props & { theme: 'light' | 'dark' }> = args => (
-  <Loader {...args} />
+  <Loading {...args} />
 );
 
 export const Default = Template.bind({});
@@ -24,8 +24,8 @@ Small.args = {
 };
 
 export default {
-  component: Loader,
-  title: 'components/Loader',
+  component: Loading,
+  title: 'components/Loading',
   args: {
     theme: 'light',
     hideText: false,

--- a/webapp/src/components/Loading.tsx
+++ b/webapp/src/components/Loading.tsx
@@ -7,7 +7,7 @@ export type Props = {
   fullPage?: boolean;
 };
 
-const Loading = ({
+export const Loading = ({
   hideText = false,
   text = 'Loading...',
   isSmall = false,
@@ -38,5 +38,3 @@ const Loading = ({
     </Box>
   </Container>
 );
-
-export default Loading;

--- a/webapp/src/components/Page.tsx
+++ b/webapp/src/components/Page.tsx
@@ -28,7 +28,7 @@ const ScreenEdge = ({ position = 'top' }: { position?: 'top' | 'bottom' }) => {
   );
 };
 
-const Page = ({
+export const Page = ({
   children,
   fullWidth = false,
 }: {
@@ -41,5 +41,3 @@ const Page = ({
     <ScreenEdge position="bottom" />
   </Box>
 );
-
-export default Page;

--- a/webapp/src/contexts/MeContext.tsx
+++ b/webapp/src/contexts/MeContext.tsx
@@ -3,7 +3,7 @@ import { createContext } from 'react';
 import { ReactNode, useEffect, useState } from 'react';
 import { useQuery } from 'react-query';
 
-import request from 'backend/request';
+import { request } from 'backend/request';
 import { Me } from 'backend/types';
 
 export interface MeContextInterface {
@@ -57,7 +57,7 @@ export const MeProvider = ({ children }: { children: ReactNode }) => {
   return <MeContext.Provider value={toProvide}>{children}</MeContext.Provider>;
 };
 
-const MeContext = createContext<{
+export const MeContext = createContext<{
   me: Me | null;
   setMe: (_: Me | null) => void;
   isLoading: boolean;
@@ -69,5 +69,3 @@ const MeContext = createContext<{
   isLoading: false,
   isError: false,
 });
-
-export default MeContext;

--- a/webapp/src/hooks/useLocalStorage.ts
+++ b/webapp/src/hooks/useLocalStorage.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 
-function useLocalStorage<Type>(
+export function useLocalStorage<Type>(
   key: string,
   defaultValue?: Type,
   opts?: { subscribe?: boolean },
@@ -65,5 +65,3 @@ function useLocalStorage<Type>(
 
   return [data, setData];
 }
-
-export default useLocalStorage;

--- a/webapp/src/hooks/useSignIn.tsx
+++ b/webapp/src/hooks/useSignIn.tsx
@@ -2,9 +2,9 @@ import { gql } from 'graphql-request';
 import { useContext, useEffect } from 'react';
 import { useMutation } from 'react-query';
 
-import request from 'backend/request';
+import { request } from 'backend/request';
 import { GraphQLError, Me, Session } from 'backend/types';
-import MeContext from 'contexts/MeContext';
+import { MeContext } from 'contexts/MeContext';
 
 export type Input = {
   email: string;
@@ -20,7 +20,7 @@ type Response = {
   session: Session;
 };
 
-const signIn = async (variables: Payload) => {
+export const signIn = async (variables: Payload) => {
   const { signIn } = await request(
     gql`
       mutation signIn($credentials: Credentials!) {
@@ -42,7 +42,7 @@ const signIn = async (variables: Payload) => {
   return signIn as Response;
 };
 
-const useSignIn = () => {
+export const useSignIn = () => {
   const { setMe } = useContext(MeContext);
   const { isLoading, data, isSuccess, mutateAsync, error } = useMutation<
     Response,
@@ -68,5 +68,3 @@ const useSignIn = () => {
     },
   };
 };
-
-export default useSignIn;

--- a/webapp/src/hooks/useSignUp.tsx
+++ b/webapp/src/hooks/useSignUp.tsx
@@ -1,7 +1,7 @@
 import { gql } from 'graphql-request';
 import { useMutation } from 'react-query';
 
-import request from 'backend/request';
+import { request } from 'backend/request';
 import { GraphQLError } from 'backend/types';
 
 export type Input = {
@@ -25,7 +25,7 @@ const signUp = async (variables: Payload) => {
   );
 };
 
-const useSignUp = () => {
+export const useSignUp = () => {
   const mutation = useMutation<void, Error | GraphQLError, Payload>(signUp);
 
   return {
@@ -35,5 +35,3 @@ const useSignUp = () => {
     signUp: (input: Input) => mutation.mutateAsync({ newUser: input }),
   };
 };
-
-export default useSignUp;

--- a/webapp/src/mocks/index.ts
+++ b/webapp/src/mocks/index.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-console, @typescript-eslint/no-var-requires */
 
-const enableMSW = () => {
+export const enableMSW = () => {
   if (typeof window === 'undefined') {
     const { server } = require('./server');
     server.listen();
@@ -16,5 +16,3 @@ const enableMSW = () => {
     });
   }
 };
-
-export default enableMSW;

--- a/webapp/src/pages/404/FourOhFour.stories.tsx
+++ b/webapp/src/pages/404/FourOhFour.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react';
 
-import FourOhFour from './FourOhFour';
+import { FourOhFour } from './FourOhFour';
 
 const Template: Story = args => <FourOhFour {...args} />;
 

--- a/webapp/src/pages/404/FourOhFour.tsx
+++ b/webapp/src/pages/404/FourOhFour.tsx
@@ -2,7 +2,7 @@ import { Box, Container, Typography } from '@mui/material';
 import type { NextPage } from 'next';
 import Head from 'next/head';
 
-const FourOhFour: NextPage = () => (
+export const FourOhFour: NextPage = () => (
   <>
     <Head>
       <title>Page Not Found</title>
@@ -36,5 +36,3 @@ const FourOhFour: NextPage = () => (
     </Container>
   </>
 );
-
-export default FourOhFour;

--- a/webapp/src/pages/404/index.tsx
+++ b/webapp/src/pages/404/index.tsx
@@ -1,2 +1,1 @@
-import FourOhFour from './FourOhFour';
-export default FourOhFour;
+export { FourOhFour } from './FourOhFour';

--- a/webapp/src/pages/home/Home.tsx
+++ b/webapp/src/pages/home/Home.tsx
@@ -5,10 +5,10 @@ import { useContext } from 'react';
 
 import styles from './Home.module.css';
 import logo from './logo.svg';
-import Loading from 'components/Loader';
-import MeContext from 'contexts/MeContext';
+import { Loading } from 'components/Loading';
+import { MeContext } from 'contexts/MeContext';
 
-const Home: NextPage = () => {
+export const Home: NextPage = () => {
   const router = useRouter();
   const { me, isLoading: isPageLoading } = useContext(MeContext);
 
@@ -38,5 +38,3 @@ const Home: NextPage = () => {
     </header>
   );
 };
-
-export default Home;

--- a/webapp/src/pages/home/index.tsx
+++ b/webapp/src/pages/home/index.tsx
@@ -1,2 +1,1 @@
-import Home from './Home';
-export default Home;
+export { Home } from './Home';

--- a/webapp/src/pages/login/Login.stories.tsx
+++ b/webapp/src/pages/login/Login.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react';
 
-import Login from './Login';
+import { Login } from './Login';
 
 const Template: Story = args => <Login {...args} />;
 

--- a/webapp/src/pages/login/Login.test.tsx
+++ b/webapp/src/pages/login/Login.test.tsx
@@ -25,15 +25,15 @@ jest.mock('next/router', () => {
   };
 });
 
-import LoadingOriginal from 'components/Loader';
-jest.mock('components/Loader');
+import { Loading as LoadingOriginal } from 'components/Loading';
+jest.mock('components/Loading');
 const Loading = jest.mocked(LoadingOriginal, true);
 
-import useSignInOriginal from 'hooks/useSignIn';
+import { useSignIn as useSignInOriginal } from 'hooks/useSignIn';
 jest.mock('hooks/useSignIn');
 const useSignIn = jest.mocked(useSignInOriginal, true);
 
-import Login from './Login';
+import { Login } from './Login';
 
 describe('Login', () => {
   beforeEach(() => {

--- a/webapp/src/pages/login/Login.tsx
+++ b/webapp/src/pages/login/Login.tsx
@@ -5,17 +5,17 @@ import { useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { isGraphQLError } from 'backend/types';
-import Link from 'components/Link';
-import Loading from 'components/Loader';
-import Page from 'components/Page';
-import MeContext from 'contexts/MeContext';
-import useSignIn, { Input as SignInInput } from 'hooks/useSignIn';
+import { Link } from 'components/Link';
+import { Loading } from 'components/Loading';
+import { Page } from 'components/Page';
+import { MeContext } from 'contexts/MeContext';
+import { Input as SignInInput, useSignIn } from 'hooks/useSignIn';
 
 type ServerErrors = {
   [key: string]: string[];
 };
 
-const Login = () => {
+export const Login = () => {
   const router = useRouter();
   const { me, isLoading: isPageLoading } = useContext(MeContext);
   const { isLoading: isSigningIn, error: signInError, signIn } = useSignIn();
@@ -177,5 +177,3 @@ const Login = () => {
     </Page>
   );
 };
-
-export default Login;

--- a/webapp/src/pages/login/index.tsx
+++ b/webapp/src/pages/login/index.tsx
@@ -1,2 +1,1 @@
-import Login from './Login';
-export default Login;
+export { Login } from './Login';

--- a/webapp/src/pages/signup/SignUp.stories.tsx
+++ b/webapp/src/pages/signup/SignUp.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, Story } from '@storybook/react';
 
-import SignUp from './SignUp';
+import { SignUp } from './SignUp';
 
 const Template: Story = args => <SignUp {...args} />;
 

--- a/webapp/src/pages/signup/SignUp.test.tsx
+++ b/webapp/src/pages/signup/SignUp.test.tsx
@@ -25,19 +25,19 @@ jest.mock('next/router', () => {
   };
 });
 
-import LoadingOriginal from 'components/Loader';
-jest.mock('components/Loader');
+import { Loading as LoadingOriginal } from 'components/Loading';
+jest.mock('components/Loading');
 const Loading = jest.mocked(LoadingOriginal, true);
 
-import useSignInOriginal from 'hooks/useSignIn';
+import { useSignIn as useSignInOriginal } from 'hooks/useSignIn';
 jest.mock('hooks/useSignIn');
 const useSignIn = jest.mocked(useSignInOriginal, true);
 
-import useSignUpOriginal from 'hooks/useSignUp';
+import { useSignUp as useSignUpOriginal } from 'hooks/useSignUp';
 jest.mock('hooks/useSignUp');
 const useSignUp = jest.mocked(useSignUpOriginal, true);
 
-import SignUp from './SignUp';
+import { SignUp } from './SignUp';
 
 describe('signUp', () => {
   beforeEach(() => {

--- a/webapp/src/pages/signup/SignUp.tsx
+++ b/webapp/src/pages/signup/SignUp.tsx
@@ -5,18 +5,18 @@ import { useContext, useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 
 import { isGraphQLError } from 'backend/types';
-import Link from 'components/Link';
-import Loading from 'components/Loader';
-import Page from 'components/Page';
-import MeContext from 'contexts/MeContext';
-import useSignIn from 'hooks/useSignIn';
-import useSignUp, { Input as SignUpInput } from 'hooks/useSignUp';
+import { Link } from 'components/Link';
+import { Loading } from 'components/Loading';
+import { Page } from 'components/Page';
+import { MeContext } from 'contexts/MeContext';
+import { useSignIn } from 'hooks/useSignIn';
+import { Input as SignUpInput, useSignUp } from 'hooks/useSignUp';
 
 type ServerErrors = {
   [key: string]: string[];
 };
 
-const SignUp = () => {
+export const SignUp = () => {
   const router = useRouter();
   const { me, isLoading: isPageLoading } = useContext(MeContext);
   const { isLoading: isSigningUp, error: signUpError, signUp } = useSignUp();
@@ -244,5 +244,3 @@ const SignUp = () => {
     </Page>
   );
 };
-
-export default SignUp;

--- a/webapp/src/pages/signup/index.tsx
+++ b/webapp/src/pages/signup/index.tsx
@@ -1,2 +1,1 @@
-import SignUp from './SignUp';
-export default SignUp;
+export { SignUp } from './SignUp';

--- a/webapp/src/providers/AppProvider.tsx
+++ b/webapp/src/providers/AppProvider.tsx
@@ -1,15 +1,13 @@
-import QueryClientProvider from 'providers/QueryClientProvider';
-import ThemeProvider from 'providers/ThemeProvider';
+import { QueryClientProvider } from 'providers/QueryClientProvider';
+import { ThemeProvider } from 'providers/ThemeProvider';
 import { ReactNode } from 'react';
 
 import { MeProvider } from 'contexts/MeContext';
 
-const AppProvider = ({ children }: { children: ReactNode }) => (
+export const AppProvider = ({ children }: { children: ReactNode }) => (
   <QueryClientProvider>
     <ThemeProvider>
       <MeProvider>{children}</MeProvider>
     </ThemeProvider>
   </QueryClientProvider>
 );
-
-export default AppProvider;

--- a/webapp/src/providers/QueryClientProvider.tsx
+++ b/webapp/src/providers/QueryClientProvider.tsx
@@ -4,7 +4,7 @@ import {
   QueryClientProvider as ExternalQueryClientProvider,
 } from 'react-query';
 
-const QueryClientProvider = ({ children }: { children: ReactNode }) => {
+export const QueryClientProvider = ({ children }: { children: ReactNode }) => {
   const client = new QueryClient();
 
   return (
@@ -13,5 +13,3 @@ const QueryClientProvider = ({ children }: { children: ReactNode }) => {
     </ExternalQueryClientProvider>
   );
 };
-
-export default QueryClientProvider;

--- a/webapp/src/providers/TestProvider.tsx
+++ b/webapp/src/providers/TestProvider.tsx
@@ -1,7 +1,7 @@
-import ThemeProvider from 'providers/ThemeProvider';
+import { ThemeProvider } from 'providers/ThemeProvider';
 import { ReactNode } from 'react';
 
-import MeContext, { MeContextInterface } from 'contexts/MeContext';
+import { MeContext, MeContextInterface } from 'contexts/MeContext';
 
 // wrapper returns a react FC that wraps the component with the all
 // needed contexts

--- a/webapp/src/providers/ThemeProvider.tsx
+++ b/webapp/src/providers/ThemeProvider.tsx
@@ -1,10 +1,13 @@
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import {
+  createTheme,
+  ThemeProvider as MuiThemeProvider,
+} from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import { ReactNode, useMemo } from 'react';
 
-import useLocalStorage from 'hooks/useLocalStorage';
+import { useLocalStorage } from 'hooks/useLocalStorage';
 
-const Theme = ({
+export const ThemeProvider = ({
   scheme,
   children,
 }: {
@@ -42,7 +45,5 @@ const Theme = ({
     [prefersLightMode],
   );
 
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+  return <MuiThemeProvider theme={theme}>{children}</MuiThemeProvider>;
 };
-
-export default Theme;


### PR DESCRIPTION
They're just a pain in the ass a provide literally nothing useful besides not having to type `{` and `}` during import.